### PR TITLE
Delete button functionality

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,8 +27,9 @@ window.onload = function() {
 
 function rightDivHandler() {
   toDoList.updateTask(event);
-  completeTask(event);
   enableDeleteButton(event);
+  completeTask(event);
+
 }
 
   function refreshPage() {
@@ -109,7 +110,7 @@ function populateToDoCard() {
       <p>URGENT</p>
       </div>
       <div class="task-delete-btn">
-        <img src="./assets/check-yo-self-icons/delete.svg" alt="">
+        <img class = "delete-btn" src="./assets/check-yo-self-icons/delete.svg" alt="">
       <p>DELETE</p>
       </div>
     </div>
@@ -174,21 +175,24 @@ function clearDraftTaskList() {
 
 // Function to enable delete button if all boxes are checked
 function enableDeleteButton(event) {
-  // if(event.target.classList.contains('empty-checkbox-img')) {
   for(var i = 0; i < window.localStorage.length; i++) {
     var toDoId = window.localStorage.key(i);
     if(event.target.parentNode.parentNode.parentNode.classList.contains(toDoId)) {
     var savedToDo = window.localStorage.getItem(toDoId);
     var parsedToDo = JSON.parse(savedToDo);
-    toDoList = parsedToDo;
-  }
-}
-  for (var j = 0; j < toDoList.tasks.length; j++) {
-    if(toDoList.allComplete.length === toDoList.tasks.length) {
-      console.log('test');
     }
   }
- }
+    if(parsedToDo.allComplete.length === parsedToDo.tasks.length) {
+      var deleteButton = event.target.closest('.saved-task-cards').querySelector('.delete-btn');
+      var deleteButtonDiv = event.target.closest('.saved-task-cards').querySelector('.task-delete-btn')
+      var activeDeleteBtn = document.createElement("img");
+      deleteButton.classList.add('hidden');
+      activeDeleteBtn.classList.add("check-box-img");
+      activeDeleteBtn.setAttribute("src", "./assets/check-yo-self-icons/delete-active.svg");
+      deleteButtonDiv.prepend(activeDeleteBtn);
+    }
+  }
+
 
 
 //

--- a/main.js
+++ b/main.js
@@ -22,17 +22,16 @@ rightDiv.addEventListener('click', rightDivHandler);
 
 
 window.onload = function() {
-  refreshPage();
+  reloadSavedCards();
 }
 
 function rightDivHandler() {
   toDoList.updateTask(event);
   enableDeleteButton(event);
   completeTask(event);
-
 }
 
-  function refreshPage() {
+  function reloadSavedCards() {
   for(var i = 0; i < window.localStorage.length; i++) {
     var savedToDo = localStorage.getItem(localStorage.key(i));
     var parsedToDo = JSON.parse(savedToDo);
@@ -91,8 +90,6 @@ function populateDraftTasks() {
   toDoList.tasks.push(taskItem);
   taskItemInput.value = "";
   addTaskButton.disabled = true;
-  console.log(taskItem);
-  console.log(toDoList);
 }
 
 
@@ -180,18 +177,26 @@ function enableDeleteButton(event) {
     if(event.target.parentNode.parentNode.parentNode.classList.contains(toDoId)) {
     var savedToDo = window.localStorage.getItem(toDoId);
     var parsedToDo = JSON.parse(savedToDo);
+      }
     }
-  }
-    if(parsedToDo.allComplete.length === parsedToDo.tasks.length) {
+    if(event.target.classList.contains('active-delete-btn')) {
+      var savedToDoCard = event.target.closest('.saved-task-cards');
+      toDoList.deleteFromStorage();
+      savedToDoCard.remove();
+    } else if (parsedToDo.allComplete.length ===            parsedToDo.tasks.length) {
       var deleteButton = event.target.closest('.saved-task-cards').querySelector('.delete-btn');
       var deleteButtonDiv = event.target.closest('.saved-task-cards').querySelector('.task-delete-btn')
       var activeDeleteBtn = document.createElement("img");
       deleteButton.classList.add('hidden');
-      activeDeleteBtn.classList.add("check-box-img");
+      activeDeleteBtn.classList.add("active-delete-btn");
       activeDeleteBtn.setAttribute("src", "./assets/check-yo-self-icons/delete-active.svg");
       deleteButtonDiv.prepend(activeDeleteBtn);
     }
   }
+
+  // function deleteToDoCard() {
+  //   var savedToDoCard = event.target.closest('.saved-task-cards');
+  //   savedToDoCard.remove();
 
 
 

--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ window.onload = function() {
 function rightDivHandler() {
   toDoList.updateTask(event);
   completeTask(event);
-  // enableDeleteButton(event);
+  enableDeleteButton(event);
 }
 
   function refreshPage() {
@@ -173,36 +173,22 @@ function clearDraftTaskList() {
 }
 
 // Function to enable delete button if all boxes are checked
-// function enableDeleteButton() {
-//   // if(event.target.classList.contains('empty-checkbox-img'))
-//   for(var i = 0; i < window.localStorage.length; i++) {
-//     var toDoId = window.localStorage.key(i);
-//     if(event.target.parentNode.parentNode.parentNode.classList.contains(toDoId)) {
-//     var savedToDo = window.localStorage.getItem(toDoId);
-//     var parsedToDo = JSON.parse(savedToDo);
-//     toDoList = parsedToDo;
-//     console.log(toDoList);
-//     }
-//   }
-//   for (var j = 0; j < toDoList.tasks.length; j++) {
-//     console.log(toDoList.tasks[j].complete);
-//     if(toDoList.tasks[j].includes(true)) {
-//       console.log('hi')
-//     }
-//     // var allFalse = toDoList.tasks[j].every(function(toDoList.tasks[j].complete === true)); {
-//     // return allFalse;
-//   }
-// }
+function enableDeleteButton(event) {
+  // if(event.target.classList.contains('empty-checkbox-img')) {
+  for(var i = 0; i < window.localStorage.length; i++) {
+    var toDoId = window.localStorage.key(i);
+    if(event.target.parentNode.parentNode.parentNode.classList.contains(toDoId)) {
+    var savedToDo = window.localStorage.getItem(toDoId);
+    var parsedToDo = JSON.parse(savedToDo);
+    toDoList = parsedToDo;
+  }
+}
+  for (var j = 0; j < toDoList.tasks.length; j++) {
+    if(toDoList.allComplete.length === toDoList.tasks.length) {
+      console.log('test');
+    }
+  }
+ }
 
 
-    // var incompleteItems = (notComplete) => notComplete.complete === false;
-    // console.log(incompleteItems);
-    // if(toDoList.tasks[j].complete === true); {
-    //
-    // }
-
-    // toDoList.tasks[j].(item => item.complete === true);
-
-
-  // for(var j = 0; j < toDoList.tasks.length; j++) {
-  //   var completedItem = toDoList.tasks[j].completed;
+//

--- a/styles.css
+++ b/styles.css
@@ -292,4 +292,8 @@ input {
 .hidden {
   display: none;
 }
+
+.enabled {
+  background: red;
+}
 /*  */

--- a/todo-list.js
+++ b/todo-list.js
@@ -11,8 +11,14 @@ class ToDoList {
     var savedTask = window.localStorage.setItem(this.id, stringedTask);
   }
   deleteFromStorage() {
-
+    for(var i = 0; i < window.localStorage.length; i++) {
+      var toDoId = window.localStorage.key(i);
+      if(event.target.parentNode.parentNode.parentNode.classList.contains(toDoId)) {
+      var savedToDo = window.localStorage.removeItem(toDoId);
+      }
+    }
   }
+  
   updateToDo() {
 
   }

--- a/todo-list.js
+++ b/todo-list.js
@@ -1,9 +1,10 @@
 class ToDoList {
-  constructor(id, title, urgent, tasks) {
+  constructor(id, title, urgent, tasks, allComplete) {
     this.id = id;
     this.title = title;
     this.urgent = false;
     this.tasks = [];
+    this.allComplete = [];
   }
   saveToStorage() {
     var stringedTask = JSON.stringify(this);
@@ -27,6 +28,9 @@ class ToDoList {
         var taskId = parsedToDo.tasks[j].id;
         if(event.target.parentNode.classList.contains(taskId)) {
         parsedToDo.tasks[j].complete = true;
+        var completedItem = parsedToDo.tasks[j].complete;
+        console.log(completedItem);
+        parsedToDo.allComplete.push(completedItem);
         var stringedTask = JSON.stringify(parsedToDo);
         var savedTask = window.localStorage.setItem(parsedToDo.id, stringedTask);
       }


### PR DESCRIPTION
####What's this PR do?
This PR completes the second user story of iteration 1 - enabling the delete button and deleting a to-do card. This means that the delete button will only be enabled if all task items are checked off. After the button is enabled, a user can click on the button and it will delete the card from the DOM and also delete the task object from local storage, so when the page is refreshed the card will no longer be there.

####Where should the reviewer start?
The reviewer should start by adding new tasks and creating a new task list. 

####How should this be manually tested?
After their task to-do card has been populated on the right side of the screen, this functionality can be tested by checking each item on the list. The user should notice that the delete button does not turn red or become enabled until all items are checked off. The user can then click the delete button and see if the card disappears. They should then refresh the page and make sure the card is no longer there.